### PR TITLE
Fix: ExampleCode Add missing Error parameter to PermissionsKit.Request callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Permissions Kit offers a developer-friendly API for requesting and checking perm
 
 ```csharp
 using VoxelBusters.PermissionsKit;
+using VoxelBusters.CoreLibrary;
 
 // Create a PermissionRequest instance
 PermissionRequest request = new PermissionRequest.Builder()
@@ -40,7 +41,7 @@ PermissionRequest request = new PermissionRequest.Builder()
                                 .Build();
 
 // Request permissions
-PermissionsKit.Request(request, (PermissionRequestResult result) =>
+PermissionsKit.Request(request, (PermissionRequestResult result, Error error) =>
 {
     if (result.Authorized())
     {


### PR DESCRIPTION
In the example code, PermissionsKit.Request must include the Error error parameter.


PermissionsKit.Request(request, (PermissionRequestResult result) =>

should be changed to
PermissionsKit.Request(request, (PermissionRequestResult result, Error error) =>